### PR TITLE
Added file metadata, and randomized initialization vectors.

### DIFF
--- a/Crypto Notepad/AES.cs
+++ b/Crypto Notepad/AES.cs
@@ -5,17 +5,95 @@ using System.Text;
 
 namespace Crypto_Notepad
 {
+    /// <summary>
+    /// This class extracts information needed for decryption from a .cnp file
+    /// </summary>
+    class AESMetadata
+    {
+        /// <summary>
+        /// Offset to actual AES data; size of metadata
+        /// </summary>
+        private int _offsetToData;
+        public int offsetToData
+        {
+            get
+            {
+                return this._offsetToData;
+            }
+        }
+        private byte[] _initialVector;
+        public byte[] initialVector
+        {
+            get
+            {
+                return this._initialVector;
+            }
+        }
+        private byte[] _salt;
+        public byte[] salt
+        {
+            get
+            {
+                return this._salt;
+            }
+        }
+
+        public AESMetadata()
+        {
+            this._initialVector = new byte[16];
+            this._salt = null;
+        }
+
+        public void DeleteMetadataFromBuffer(ref byte[] rawData)
+        {
+            // Possibly unsafe
+            byte[] buffer = new byte[rawData.Length - this.offsetToData];
+            System.Buffer.BlockCopy(rawData, this.offsetToData, buffer, 0, rawData.Length - this.offsetToData);
+            rawData = buffer;
+        }
+
+        public void GetMetadata(byte[] rawData)
+        {
+            int index = 0;
+            // Read initialVector
+            for (int i = 0; index < rawData.Length; index++, i++)
+            {
+                if (rawData[index] == '\0') // Null terminator
+                {
+                    index++;
+                    break;
+                }
+                this.initialVector[i] = rawData[index];
+            }
+            // This is kind of a dirty fix, but it gets the job done
+            // Get length of salt
+            int length = 0;
+            for (int i = index; i < rawData.Length; i++)
+            {
+                if (rawData[i] == '\0') // Null terminator
+                {
+                    index++;
+                    break;
+                }
+                length++;
+            }
+            // Copy bytes into this.salt
+            this._salt = new byte[length];
+            System.Buffer.BlockCopy(rawData, index - 1, this.salt, 0, length);
+
+            this._offsetToData = this.salt.Length + 1 + this.initialVector.Length + 1;
+        }
+    }
+
     class AES
     {
-        public static string Encrypt(string plainText, string password,
+        public static string Encrypt(string plainText, string password, byte[] initialVectorBytes,
         string salt = "Kosher", string hashAlgorithm = "SHA1",
-        int passwordIterations = 2, string initialVector = "OFRna73m*aze01xY",
-        int keySize = 256)
+        int passwordIterations = 2, int keySize = 256)
         {
             if (string.IsNullOrEmpty(plainText))
                 return "";
 
-            byte[] initialVectorBytes = Encoding.ASCII.GetBytes(initialVector);
             byte[] saltValueBytes = Encoding.ASCII.GetBytes(salt);
             byte[] plainTextBytes = Encoding.UTF8.GetBytes(plainText);
 
@@ -28,10 +106,16 @@ namespace Crypto_Notepad
 
             byte[] cipherTextBytes = null;
 
-            using (ICryptoTransform encryptor = symmetricKey.CreateEncryptor
-            (keyBytes, initialVectorBytes))
+            using (MemoryStream memStream = new MemoryStream())
             {
-                using (MemoryStream memStream = new MemoryStream())
+                byte[] nullByte = { 0 };
+                memStream.Write(initialVectorBytes, 0, initialVectorBytes.Length);
+                memStream.Write(nullByte, 0, 1);
+                memStream.Write(saltValueBytes, 0, saltValueBytes.Length);
+                memStream.Write(nullByte, 0, 1);
+
+                using (ICryptoTransform encryptor = symmetricKey.CreateEncryptor
+                (keyBytes, initialVectorBytes))
                 {
                     using (CryptoStream cryptoStream = new CryptoStream
                              (memStream, encryptor, CryptoStreamMode.Write))
@@ -45,24 +129,31 @@ namespace Crypto_Notepad
                 }
             }
 
-            symmetricKey.Clear();
+            symmetricKey.Dispose();
             return Convert.ToBase64String(cipherTextBytes);
         }
 
         public static string Decrypt(string cipherText, string password,
-        string salt = "Kosher", string hashAlgorithm = "SHA1",
-        int passwordIterations = 2, string initialVector = "OFRna73m*aze01xY",
+        string hashAlgorithm = "SHA1",
+        int passwordIterations = 2,
         int keySize = 256)
         {
             if (string.IsNullOrEmpty(cipherText))
                 return "";
 
-            byte[] initialVectorBytes = Encoding.ASCII.GetBytes(initialVector);
-            byte[] saltValueBytes = Encoding.ASCII.GetBytes(salt);
+            byte[] initialVectorBytes;
+            byte[] saltValueBytes;
             byte[] cipherTextBytes = Convert.FromBase64String(cipherText);
 
+            // Extract metadata from file
+            AESMetadata metadata = new AESMetadata();
+            metadata.GetMetadata(cipherTextBytes);
+            saltValueBytes = metadata.salt;
+            initialVectorBytes = metadata.initialVector;
+            metadata.DeleteMetadataFromBuffer(ref cipherTextBytes);
+
             PasswordDeriveBytes derivedPassword = new PasswordDeriveBytes
-            (password, saltValueBytes, hashAlgorithm, passwordIterations);
+                (password, saltValueBytes, hashAlgorithm, passwordIterations);
             byte[] keyBytes = derivedPassword.GetBytes(keySize / 8);
 
             RijndaelManaged symmetricKey = new RijndaelManaged();
@@ -71,10 +162,10 @@ namespace Crypto_Notepad
             byte[] plainTextBytes = new byte[cipherTextBytes.Length];
             int byteCount = 0;
 
-            using (ICryptoTransform decryptor = symmetricKey.CreateDecryptor
-                     (keyBytes, initialVectorBytes))
+            using (MemoryStream memStream = new MemoryStream(cipherTextBytes))
             {
-                using (MemoryStream memStream = new MemoryStream(cipherTextBytes))
+                using (ICryptoTransform decryptor = symmetricKey.CreateDecryptor
+                         (keyBytes, initialVectorBytes))
                 {
                     using (CryptoStream cryptoStream
                     = new CryptoStream(memStream, decryptor, CryptoStreamMode.Read))
@@ -84,9 +175,10 @@ namespace Crypto_Notepad
                         cryptoStream.Close();
                     }
                 }
-            }
 
-            symmetricKey.Clear();
+                symmetricKey.Dispose();
+            }
+            
             return Encoding.UTF8.GetString(plainTextBytes, 0, byteCount);
         }
     }

--- a/Crypto Notepad/Form1.cs
+++ b/Crypto Notepad/Form1.cs
@@ -51,7 +51,7 @@ namespace Crypto_Notepad
                 DialogResult res = new DialogResult();
                 using (new CenterWinDialog(this))
                 {
-                    res = MessageBox.Show("Get The Salt from mac address? (You can edit it by himself in Settings)", "Crypto Notepad",
+                    res = MessageBox.Show("Get The Salt from mac address? (You can change it yourself in Settings)", "Crypto Notepad",
                 MessageBoxButtons.YesNo, MessageBoxIcon.Question);
                 }
 
@@ -88,7 +88,7 @@ namespace Crypto_Notepad
             {
                 string opnfile = File.ReadAllText(OpenFile.FileName);
                 string NameWithotPath = Path.GetFileName(OpenFile.FileName);
-                string de = AES.Decrypt(opnfile, publicVar.encryptionKey, ps.TheSalt, ps.HashAlgorithm, ps.PasswordIterations, "16CHARSLONG12345", ps.KeySize);
+                string de = AES.Decrypt(opnfile, publicVar.encryptionKey, ps.HashAlgorithm, ps.PasswordIterations, ps.KeySize);
                 customRTB.Text = de;
 
                 this.Text = appName + NameWithotPath;
@@ -165,7 +165,7 @@ namespace Crypto_Notepad
                 }
                 publicVar.okPressed = false;
 
-                string de = AES.Decrypt(opnfile, publicVar.encryptionKey, ps.TheSalt, ps.HashAlgorithm, ps.PasswordIterations, "16CHARSLONG12345", ps.KeySize);
+                string de = AES.Decrypt(opnfile, publicVar.encryptionKey, ps.HashAlgorithm, ps.PasswordIterations, ps.KeySize);
                 customRTB.Text = de;
 
                 this.Text = appName + NameWithotPath;
@@ -234,8 +234,15 @@ namespace Crypto_Notepad
 
             filename = SaveFile.FileName;
 
+            // Generate random initialization vector
+            RandomNumberGenerator RandNumGen = RNGCryptoServiceProvider.Create();
+            byte[] RandInitVector = new byte[16];
+            RandNumGen.GetNonZeroBytes(RandInitVector);
+
             string noenc = customRTB.Text;
-            string en = AES.Encrypt(customRTB.Text, publicVar.encryptionKey, ps.TheSalt, ps.HashAlgorithm, ps.PasswordIterations, "16CHARSLONG12345", ps.KeySize);
+            string en = AES.Encrypt(customRTB.Text, publicVar.encryptionKey, RandInitVector, ps.TheSalt, ps.HashAlgorithm, ps.PasswordIterations, ps.KeySize);
+            RandNumGen.Dispose();
+
             customRTB.Text = en;
             StreamWriter sw = new StreamWriter(filename);
             int i = customRTB.Lines.Count();
@@ -374,8 +381,15 @@ namespace Crypto_Notepad
                 publicVar.okPressed = false;
             }
 
+            // Generate random initialization vector
+            RandomNumberGenerator RandNumGen = RNGCryptoServiceProvider.Create();
+            byte[] RandInitVector = new byte[16];
+            RandNumGen.GetNonZeroBytes(RandInitVector);
+
             string noenc = customRTB.Text;
-            string en = AES.Encrypt(customRTB.Text, publicVar.encryptionKey, ps.TheSalt, ps.HashAlgorithm, ps.PasswordIterations, "16CHARSLONG12345", ps.KeySize);
+            string en = AES.Encrypt(customRTB.Text, publicVar.encryptionKey, RandInitVector, ps.TheSalt, ps.HashAlgorithm, ps.PasswordIterations, ps.KeySize);
+            RandNumGen.Dispose();
+
             customRTB.Text = en;
             StreamWriter sw = new StreamWriter(filename);
             int i = customRTB.Lines.Count();
@@ -936,7 +950,7 @@ namespace Crypto_Notepad
                 OpenFile.FileName = filename;
                 string opnfile = File.ReadAllText(OpenFile.FileName);
                 string NameWithotPath = Path.GetFileName(OpenFile.FileName);
-                string de = AES.Decrypt(opnfile, publicVar.encryptionKey, ps.TheSalt, ps.HashAlgorithm, ps.PasswordIterations, "16CHARSLONG12345", ps.KeySize);
+                string de = AES.Decrypt(opnfile, publicVar.encryptionKey, ps.HashAlgorithm, ps.PasswordIterations, ps.KeySize);
 
                 this.Text = appName + NameWithotPath;
                 filename = OpenFile.FileName;

--- a/Crypto Notepad/Form2.cs
+++ b/Crypto Notepad/Form2.cs
@@ -7,6 +7,8 @@ namespace Crypto_Notepad
     {
         public Form2()
         {
+            // Initialize to false in case user presses the exit button
+            publicVar.okPressed = false;
             InitializeComponent();
         }
 


### PR DESCRIPTION
I attempted to fix some things in this commit.

- A minor grammar mistake
- Unrandomized initialization vectors
- Salt not being stored as metadata

The reason I created a metadata class is that I felt that the salt and initialization vector should be stored in the file.

Cryptographic salts are mainly supposed to just be used for protection against hash lookup-tables. Therefore I thought that storing it in the file as metadata wouldn't cause any harm, and would also prevent loading errors that would occur when the user has changed the salt in the options.

I also stored the initialization vector in the metadata so the program would be able to initialize the AES algorithm with the same values. I'm not 100% sure if this was the right way to do it, but if it wasn't please edit my code! :smile: 